### PR TITLE
BLD: add script enrty point

### DIFF
--- a/parse_and_visualize/parse_and_visualize.py
+++ b/parse_and_visualize/parse_and_visualize.py
@@ -161,7 +161,7 @@ def populate_matrix_smart(matrix, horizontal, vertical):
     return matrix
 
 
-if __name__ == '__main__':
+def cli():
     import argparse
 
     parser = argparse.ArgumentParser(description='Plot image based on input file')
@@ -237,3 +237,6 @@ if __name__ == '__main__':
         cs.update_image(matrix)
         plt.show()
 
+
+if __name__ == '__main__':
+    cli()

--- a/setup.py
+++ b/setup.py
@@ -41,4 +41,7 @@ setup(
     tests_require=test_requirements,
     url='https://github.com/kalebswartz7/parse-and-visualize',
     zip_safe=False,
+    entry_points={
+        "console_scripts": ['SRW-parser = parse_and_visualize.parse_and_visualize:cli']
+    },
 )


### PR DESCRIPTION
This allows to execute the package as a script. Example:
```bash
$ SRW-parser -h
usage: SRW-parser [-h] [-d DAT_FILE] [-vp VERT_POS] [-hp HORIZ_POS]
                  [-vl VERT_LABEL] [-hl HORIZ_LABEL]
                  [-e EXTENT_LABELS [EXTENT_LABELS ...]]

Plot image based on input file

optional arguments:
  -h, --help            show this help message and exit
  -d DAT_FILE, --dat_file DAT_FILE
                        input .dat file
  -vp VERT_POS, --vert_pos VERT_POS
                        input vertical slice position
  -hp HORIZ_POS, --horiz_pos HORIZ_POS
                        input horizontal slice position
  -vl VERT_LABEL, --vert_label VERT_LABEL
                        input vertical label string
  -hl HORIZ_LABEL, --horiz_label HORIZ_LABEL
                        input horizontal label string
  -e EXTENT_LABELS [EXTENT_LABELS ...], --extent_labels EXTENT_LABELS [EXTENT_LABELS ...]
                        input extent labels for image ranges
```